### PR TITLE
add redirect

### DIFF
--- a/releases/index.html
+++ b/releases/index.html
@@ -2,6 +2,7 @@
 layout: release
 title: Releases &middot; CellProfiler
 redirect_from: "/download.html"
+redirect_from: "/downloadCPA.html"
 ---
 
 


### PR DESCRIPTION
Googling for "CellProfiler Analyst download" pulls up the old downloadCPA.html page.   I think this old page should be decommissioned and the new releases page should replace it. 
